### PR TITLE
Agrege el packageLockJson al gitignore

### DIFF
--- a/Client/.gitignore
+++ b/Client/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+
+# package-lock.json
+package-lock.json


### PR DESCRIPTION
Se agrego el packageLockJson al gitignore para evitar problemas de versiones en las dependencias